### PR TITLE
Added "Cloud" button to Roo Code. Allows to login to Roo Code Cloud

### DIFF
--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/roo/RooCodeButtonProvider.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/extensions/plugin/roo/RooCodeButtonProvider.kt
@@ -40,6 +40,7 @@ class RooCodeButtonProvider : ExtensionButtonProvider {
             MCPButtonClickAction(),
             HistoryButtonClickAction(),
             MarketplaceButtonClickAction(),
+            CloudButtonClickAction(),
             SettingsButtonClickAction()
         )
     }
@@ -157,6 +158,31 @@ class RooCodeButtonProvider : ExtensionButtonProvider {
          */
         override fun actionPerformed(e: AnActionEvent) {
             logger.info("History button clicked")
+            executeCommand(commandId, e.project)
+        }
+    }
+
+    /**
+     * Action that handles clicks on the Cloud button in the UI.
+     * Executes the corresponding VSCode command when triggered.
+     */
+    class CloudButtonClickAction : AnAction() {
+        private val logger: Logger = Logger.getInstance(CloudButtonClickAction::class.java)
+        private val commandId: String = "roo-cline.cloudButtonClicked"
+
+        init {
+            templatePresentation.icon = AllIcons.Javaee.WebService
+            templatePresentation.text = "Cloud"
+            templatePresentation.description = "Cloud"
+        }
+
+        /**
+         * Performs the action when the Cloud button is clicked.
+         *
+         * @param e The action event containing context information
+         */
+        override fun actionPerformed(e: AnActionEvent) {
+            logger.info("Cloud button clicked")
             executeCommand(commandId, e.project)
         }
     }


### PR DESCRIPTION
Fixes #78

This PR adds a new "Cloud" button for Roo Code.
When connecting to Roo Code Cloud via this button, clicking the "Having trouble?" link allows users to manually copy their credentials and successfully log in to Roo Code Cloud.
<img width="823" height="29" alt="obraz" src="https://github.com/user-attachments/assets/7968c8d6-3d40-4633-ba43-fa5ff1e4f7fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Cloud" button to quickly access cloud-related features from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->