### PR TITLE
Fix for multiple workspaces not working

### DIFF
--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadLanguageModelToolsShape.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadLanguageModelToolsShape.kt
@@ -6,7 +6,6 @@ package com.sina.weibo.agent.actors
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
-import com.sina.weibo.agent.plugin.SystemObjectProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadTaskShape.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadTaskShape.kt
@@ -6,7 +6,6 @@ package com.sina.weibo.agent.actors
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
-import com.sina.weibo.agent.plugin.SystemObjectProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadWindowShape.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/actors/MainThreadWindowShape.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
-import com.sina.weibo.agent.plugin.SystemObjectProvider
 import com.sina.weibo.agent.plugin.WecoderPluginService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/plugin/WecoderPlugin.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/plugin/WecoderPlugin.kt
@@ -141,7 +141,7 @@ class WecoderPlugin : StartupActivity.DumbAware {
                     LOG.info("Disposing RunVSAgent plugin for project: ${project.name}")
                     pluginService.dispose()
                     extensionManager.dispose()
-                    SystemObjectProvider.dispose()
+                    SystemObjectProvider.dispose(project)
                 })
                 
                 LOG.info("RunVSAgent plugin initialized successfully for project: ${project.name}")
@@ -359,7 +359,7 @@ class WecoderPluginService(private var currentProject: Project) : Disposable {
         udsSocketServer.project = project
         
         // Register to system object provider
-        SystemObjectProvider.register("pluginService", this)
+        SystemObjectProvider.register(project, "pluginService", this)
         
         // Start initialization in background thread
         coroutineScope.launch {

--- a/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ui/RunVSAgentToolWindowFactory.kt
+++ b/jetbrains_plugin/src/main/kotlin/com/sina/weibo/agent/ui/RunVSAgentToolWindowFactory.kt
@@ -1271,7 +1271,7 @@ class RunVSAgentToolWindowFactory : ToolWindowFactory {
                         logger.info("Disposing RunVSAgent plugin for project: ${project.name}")
                         pluginService.dispose()
                         extensionManager.dispose()
-                        SystemObjectProvider.dispose()
+                        SystemObjectProvider.dispose(project)
                         // Reset state when disposing
                         isPluginRunning = false
                         isPluginStarting = false


### PR DESCRIPTION
Fixes #98

This PR possibly fixes multiple workspaces problem.

Instance state is tied to a single Project. Services like WebViewManager and WecoderPluginService are marked with @Service(Service.Level.PROJECT) and store the active WebViewInstance and RPC connection in project-scoped fields (WebViewManager.getLatestWebView(), PluginContext.getRPCProtocol()), but they also relied on static/singleton access (WecoderPlugin.getInstance(project), PluginContext.getInstance(project)). When a second IDE window opens, the new project gets fresh service instances while the extension process was still running for the first project. The new window never registered a WebView because the extension host remained bound to the earlier ExtensionHostManager, so the RunVSAgentToolWindowContent placeholder kept showing, producing e.g. the blank web view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal resource management to operate on a per-project basis instead of using global storage.
  * Removed unused imports from several internal components.
  * Updated resource lifecycle methods to align with per-project resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->